### PR TITLE
Add CircleCI Integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,8 @@ jobs:
       - run: yarn install
       - run: cd gui && yarn install
       - run: yarn build --publish=never
+      - store_artifacts:
+          path: /home/circleci/project/_releases
 workflows:
   version: 2
   build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,10 @@ jobs:
       - image: circleci/node:12.9.1
     steps:
       - checkout
+      - run: sudo apt update && sudo apt install rsync
+      - run: yarn install
+      - run: cd gui && yarn install
+      - run: yarn build --publish=never
 workflows:
   version: 2
   build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:12.9.1
+    steps:
+      - checkout
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build
+


### PR DESCRIPTION
I primarily run CloudRig on linux, and I've had to build it a few times locally. I always end up getting odd errors, so I figured it would be easier to automate it so I don't have to mess with it next time. CircleCI offers free builds for OSS projects, so it can't hurt to have it enabled.

Next steps for this project would be: 
* add a linting step
* add a macos build step (still free, but requires [emailing them to request that it be enabled](https://circleci.com/open-source/))
* add a step that builds for windows (I'm not sure _why_ you'd want to use cloudrig on windows, but it's easy enough to support)
* integrate build artifacts with releases

Building for osx/windows should be pretty doable in circleci. [Here](https://github.com/joeireland/electron-circleci/blob/d7ea472c4672db9ade62ff6bd96fc059453ae1a6/.circleci/config.yml)'s a basic example.

I don't think these checks are relevant, but I'll leave them here anyway
- [ ] Code is linted
- [ ] Changelog has been updated
- [ ] Version has been updated
